### PR TITLE
chart.lines: some cleanup.

### DIFF
--- a/charts.factor
+++ b/charts.factor
@@ -1,6 +1,6 @@
 ! Copyright (C) 2016-2017 Alexander Ilin.
 ! See http://factorcode.org/license.txt for BSD license.
-USING: kernel ui.gadgets ;
+USING: accessors kernel ui.gadgets ;
 IN: charts
 
 TUPLE: chart < gadget ;
@@ -11,13 +11,12 @@ M: chart pref-dim* drop { 300 300 } ;
 : chart-axes ( chart -- seq )
     drop { { 0 300 } { 0 300 } } ;
 
-! Return the width and height of the visible area, in pixels.
-: chart-dim ( chart -- seq )
-    drop { 300 300 } ;
+! Return the { width height } of the visible area, in pixels.
+: chart-dim ( chart -- seq ) dim>> ;
 
 ! There are several things to do to present data on the screen.
 ! Map the data coordinates to the screen coordinates.
 ! Cut off data outside the presentation window. When cutting off vertically, split the line into segments and add new points if necessary. Return an array of line segments.
 ! Remove redundant points from the drawing pass.
 
-! chart new line new COLOR: blue >>color { { 0 100 } { 100 0 } { 100 50 } { 150 50 } { 200 100 } } >>data add-gadget gadget.
+! chart new line new COLOR: blue >>color { { 0 100 } { 100 0 } { 100 50 } { 150 50 } { 200 100 } } >>data add-gadget "Chart" open-window


### PR DESCRIPTION
I made a little bit of cleanup.

Some observations:

* ``middle`` is not really useful now that the only use does ``2 *`` which is effectively just ``min max +``

* It's a lot easier to use someone's factor repo if you have the project able to be used as a ``.factor-roots``, which would imply making a ``charts`` directory and moving all the current files into it... then probably having a ``README`` and ``LICENSE`` etc. at the top level.

* You don't really have to ``{ } clone``, it's okay to just return an empty array.

* I don't know if it would be useful but ``math.points`` in ``extra`` has some words like ``slope`` for working with points.  Maybe that can be used / improved for the stuff you're doing.

* ``each2*`` is just ``[ ] swap map-reduce`` so I inlined it.

* You do a lot of ``first`` and ``second``... it might be worth using your aliases ``x`` and ``y`` but also maybe making higher level words to work with point objects...